### PR TITLE
fix build by requiring wx widgets version 3.1.4 and including wx/image.h

### DIFF
--- a/src/Applications/Application/CMakeLists.txt
+++ b/src/Applications/Application/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(Application)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Application.cpp)

--- a/src/Applications/ApplicationAndAssert/CMakeLists.txt
+++ b/src/Applications/ApplicationAndAssert/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(ApplicationAndAssert)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES ApplicationAndAssert.cpp)

--- a/src/Applications/ApplicationAndException/CMakeLists.txt
+++ b/src/Applications/ApplicationAndException/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(ApplicationAndException)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES ApplicationAndException.cpp)

--- a/src/Applications/ApplicationAndMain/CMakeLists.txt
+++ b/src/Applications/ApplicationAndMain/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(ApplicationAndMain)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES ApplicationAndMain.cpp)

--- a/src/Applications/ApplicationAndMain2/CMakeLists.txt
+++ b/src/Applications/ApplicationAndMain2/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(ApplicationAndMain2)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES

--- a/src/Applications/ApplicationIcon/CMakeLists.txt
+++ b/src/Applications/ApplicationIcon/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(ApplicationIcon)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES ApplicationIcon.cpp)

--- a/src/BookControls/Choicebook/CMakeLists.txt
+++ b/src/BookControls/Choicebook/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Choicebook)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/BookControls/Listbook/CMakeLists.txt
+++ b/src/BookControls/Listbook/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Listbook)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/BookControls/Notebook/CMakeLists.txt
+++ b/src/BookControls/Notebook/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Notebook)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/BookControls/Simplebook/CMakeLists.txt
+++ b/src/BookControls/Simplebook/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Simplebook)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/BookControls/Toolbook/CMakeLists.txt
+++ b/src/BookControls/Toolbook/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Toolbook)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/BookControls/Treebook/CMakeLists.txt
+++ b/src/BookControls/Treebook/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Treebook)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/ActivityIndicator/CMakeLists.txt
+++ b/src/CommonControls/ActivityIndicator/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(ActivityIndicator)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES ActivityIndicator.cpp)

--- a/src/CommonControls/AnimationCtrl/CMakeLists.txt
+++ b/src/CommonControls/AnimationCtrl/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(AnimationCtrl)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES AnimationCtrl.cpp)

--- a/src/CommonControls/BitmapButton/CMakeLists.txt
+++ b/src/CommonControls/BitmapButton/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(BitmapButton)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES BitmapButton.cpp gammasoft_16x16.xpm gammasoft_64x64.xpm)

--- a/src/CommonControls/Button/CMakeLists.txt
+++ b/src/CommonControls/Button/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(Button)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Button.cpp)

--- a/src/CommonControls/CalendarCtrl/CMakeLists.txt
+++ b/src/CommonControls/CalendarCtrl/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(CalendarCtrl)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES CalendarCtrl.cpp)

--- a/src/CommonControls/CheckBox/CMakeLists.txt
+++ b/src/CommonControls/CheckBox/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(CheckBox)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES CheckBox.cpp)

--- a/src/CommonControls/CheckListBox/CMakeLists.txt
+++ b/src/CommonControls/CheckListBox/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(CheckListBox)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES CheckListBox.cpp)

--- a/src/CommonControls/Choice/CMakeLists.txt
+++ b/src/CommonControls/Choice/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(Choice)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Choice.cpp)

--- a/src/CommonControls/ComboBox/CMakeLists.txt
+++ b/src/CommonControls/ComboBox/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(ComboBox)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES ComboBox.cpp)

--- a/src/CommonControls/CommandLinkButton/CMakeLists.txt
+++ b/src/CommonControls/CommandLinkButton/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(CommandLinkButton)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES CommandLinkButton.cpp)

--- a/src/CommonControls/Control/CMakeLists.txt
+++ b/src/CommonControls/Control/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(Control)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Control.cpp)

--- a/src/CommonControls/DirCtrl/CMakeLists.txt
+++ b/src/CommonControls/DirCtrl/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(DirCtrl)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES DirCtrl.cpp)

--- a/src/CommonControls/FileCtrl/CMakeLists.txt
+++ b/src/CommonControls/FileCtrl/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(FileCtrl)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES FileCtrl.cpp)

--- a/src/CommonControls/Gauge/CMakeLists.txt
+++ b/src/CommonControls/Gauge/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(Gauge)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Gauge.cpp)

--- a/src/CommonControls/GenericStaticBitmap/CMakeLists.txt
+++ b/src/CommonControls/GenericStaticBitmap/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(GenericStaticBitmap)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES GenericStaticBitmap.cpp Logo.xpm)

--- a/src/CommonControls/HyperlinkCtrl/CMakeLists.txt
+++ b/src/CommonControls/HyperlinkCtrl/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(HyperlinkCtrl)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HyperlinkCtrl.cpp)

--- a/src/CommonControls/ListBox/CMakeLists.txt
+++ b/src/CommonControls/ListBox/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ListBox)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/ListCtrl/CMakeLists.txt
+++ b/src/CommonControls/ListCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ListCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/RadioButton/CMakeLists.txt
+++ b/src/CommonControls/RadioButton/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(RadioButton)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/RichToolTip/CMakeLists.txt
+++ b/src/CommonControls/RichToolTip/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(RichToolTip)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/ScrollBar/CMakeLists.txt
+++ b/src/CommonControls/ScrollBar/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ScrollBar)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/SearchCtrl/CMakeLists.txt
+++ b/src/CommonControls/SearchCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SearchCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/Slider/CMakeLists.txt
+++ b/src/CommonControls/Slider/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Slider)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/SpinButton/CMakeLists.txt
+++ b/src/CommonControls/SpinButton/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SpinButton)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/SpinCtrl/CMakeLists.txt
+++ b/src/CommonControls/SpinCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SpinCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/SpinCtrlDouble/CMakeLists.txt
+++ b/src/CommonControls/SpinCtrlDouble/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SpinCtrlDouble)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/StaticBitmap/CMakeLists.txt
+++ b/src/CommonControls/StaticBitmap/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticBitmap)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/StaticBitmap2/CMakeLists.txt
+++ b/src/CommonControls/StaticBitmap2/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticBitmap2)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/StaticLine/CMakeLists.txt
+++ b/src/CommonControls/StaticLine/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticLine)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/StaticText/CMakeLists.txt
+++ b/src/CommonControls/StaticText/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticText)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/TaskBarIcon/CMakeLists.txt
+++ b/src/CommonControls/TaskBarIcon/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TaskBarIcon)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/TextCtrl/CMakeLists.txt
+++ b/src/CommonControls/TextCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TextCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/ToggleButton/CMakeLists.txt
+++ b/src/CommonControls/ToggleButton/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ToggleButton)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonControls/TreeCtrl/CMakeLists.txt
+++ b/src/CommonControls/TreeCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TreeCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/ColourDialog/CMakeLists.txt
+++ b/src/CommonDialogs/ColourDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ColourDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/DirDialog/CMakeLists.txt
+++ b/src/CommonDialogs/DirDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(DirDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/FontDialog/CMakeLists.txt
+++ b/src/CommonDialogs/FontDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FontDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/MultiChoiceDialog/CMakeLists.txt
+++ b/src/CommonDialogs/MultiChoiceDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(MultiChoiceDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/NumberEntryDialog/CMakeLists.txt
+++ b/src/CommonDialogs/NumberEntryDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(NumberEntryDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/OpenFileDialog/CMakeLists.txt
+++ b/src/CommonDialogs/OpenFileDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(OpenFileDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/PasswordEntryDialog/CMakeLists.txt
+++ b/src/CommonDialogs/PasswordEntryDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(PasswordEntryDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/RearrangeDialog/CMakeLists.txt
+++ b/src/CommonDialogs/RearrangeDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(RearrangeDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/SaveFileDialog/CMakeLists.txt
+++ b/src/CommonDialogs/SaveFileDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SaveFileDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/SingleChoiceDialog/CMakeLists.txt
+++ b/src/CommonDialogs/SingleChoiceDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SingleChoiceDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CommonDialogs/TextEntryDialog/CMakeLists.txt
+++ b/src/CommonDialogs/TextEntryDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TextEntryDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/ArtProvider/CMakeLists.txt
+++ b/src/Components/ArtProvider/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ArtProvider)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/BusyCursor/CMakeLists.txt
+++ b/src/Components/BusyCursor/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(BusyCursor)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/Config/CMakeLists.txt
+++ b/src/Components/Config/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Config)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/Config2/CMakeLists.txt
+++ b/src/Components/Config2/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Config2)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/Cursor/CMakeLists.txt
+++ b/src/Components/Cursor/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Cursor)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/ImageList/CMakeLists.txt
+++ b/src/Components/ImageList/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ImageList)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/Timer/CMakeLists.txt
+++ b/src/Components/Timer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Timer)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Components/ToolTip/CMakeLists.txt
+++ b/src/Components/ToolTip/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ToolTip)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/ContainerControls/CollapsiblePane/CMakeLists.txt
+++ b/src/ContainerControls/CollapsiblePane/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(CollapsiblePane)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/ContainerControls/Frame/CMakeLists.txt
+++ b/src/ContainerControls/Frame/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Frame)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/ContainerControls/Panel/CMakeLists.txt
+++ b/src/ContainerControls/Panel/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Panel)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/ContainerControls/RadioBox/CMakeLists.txt
+++ b/src/ContainerControls/RadioBox/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(RadioBox)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/ContainerControls/SplitterWindow/CMakeLists.txt
+++ b/src/ContainerControls/SplitterWindow/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SplitterWindow)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/ContainerControls/StaticBox/CMakeLists.txt
+++ b/src/ContainerControls/StaticBox/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticBox)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/ContainerControls/StaticBoxSizerVertical/CMakeLists.txt
+++ b/src/ContainerControls/StaticBoxSizerVertical/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticBoxSizerVertical)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CustomControls/DomainSpinCtrl/CMakeLists.txt
+++ b/src/CustomControls/DomainSpinCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(DomainSpinCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CustomControls/Line/CMakeLists.txt
+++ b/src/CustomControls/Line/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Line)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CustomControls/NumericTextCtrl/CMakeLists.txt
+++ b/src/CustomControls/NumericTextCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(NumericTextCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/CustomDialogs/UserDialog/CMakeLists.txt
+++ b/src/CustomDialogs/UserDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(UserDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/AboutBox/CMakeLists.txt
+++ b/src/Dialogs/AboutBox/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(AboutBox)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/BusyInfo/CMakeLists.txt
+++ b/src/Dialogs/BusyInfo/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(BusyInfo)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/FindReplaceDialog/CMakeLists.txt
+++ b/src/Dialogs/FindReplaceDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FindReplaceDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/GenericAboutBox/CMakeLists.txt
+++ b/src/Dialogs/GenericAboutBox/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(GenericAboutBox)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/GenericFindReplaceDialog/CMakeLists.txt
+++ b/src/Dialogs/GenericFindReplaceDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(GenericFindReplaceDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/GenericProgressDialog/CMakeLists.txt
+++ b/src/Dialogs/GenericProgressDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(GenericProgressDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/MessageDialog/CMakeLists.txt
+++ b/src/Dialogs/MessageDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(MessageDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/PrintAbortDialog/CMakeLists.txt
+++ b/src/Dialogs/PrintAbortDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(PrintAbortDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/ProgressDialog/CMakeLists.txt
+++ b/src/Dialogs/ProgressDialog/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ProgressDialog)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Dialogs/Wizard/CMakeLists.txt
+++ b/src/Dialogs/Wizard/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Wizard)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/ApplicationIdle/CMakeLists.txt
+++ b/src/Events/ApplicationIdle/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ApplicationIdle)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/CustomEvent/CMakeLists.txt
+++ b/src/Events/CustomEvent/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(CustomEvent)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/FrameAndEvents/CMakeLists.txt
+++ b/src/Events/FrameAndEvents/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FrameAndEvents)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/FrameClick/CMakeLists.txt
+++ b/src/Events/FrameClick/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FrameClick)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/FramePaint/CMakeLists.txt
+++ b/src/Events/FramePaint/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FramePaint)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/KeyEvents/CMakeLists.txt
+++ b/src/Events/KeyEvents/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(KeyEvents)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/MouseEvents/CMakeLists.txt
+++ b/src/Events/MouseEvents/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(MouseEvents)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Events/ProcessEvent/CMakeLists.txt
+++ b/src/Events/ProcessEvent/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ProcessEvent)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/HelloWorlds/HelloWorldEmoticons/CMakeLists.txt
+++ b/src/HelloWorlds/HelloWorldEmoticons/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(HelloWorldEmoticons)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HelloWorldEmoticons.cpp)

--- a/src/HelloWorlds/HelloWorldGenericStaticText/CMakeLists.txt
+++ b/src/HelloWorlds/HelloWorldGenericStaticText/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(HelloWorldGenericStaticText)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HelloWorldGenericStaticText.cpp)

--- a/src/HelloWorlds/HelloWorldMessageDialog/CMakeLists.txt
+++ b/src/HelloWorlds/HelloWorldMessageDialog/CMakeLists.txt
@@ -3,7 +3,7 @@ project(HelloWorldMessageDialog)
 
 # Project
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HelloWorldMessageDialog.cpp)

--- a/src/HelloWorlds/HelloWorldMessageDialog2/CMakeLists.txt
+++ b/src/HelloWorlds/HelloWorldMessageDialog2/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(HelloWorldMessageDialog2)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HelloWorldMessageDialog2.cpp)

--- a/src/HelloWorlds/HelloWorldPaint/CMakeLists.txt
+++ b/src/HelloWorlds/HelloWorldPaint/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(HelloWorldPaint)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HelloWorldPaint.cpp)

--- a/src/HelloWorlds/HelloWorldSay/CMakeLists.txt
+++ b/src/HelloWorlds/HelloWorldSay/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(HelloWorldSay)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HelloWorldSay.cpp)

--- a/src/HelloWorlds/HelloWorldStaticText/CMakeLists.txt
+++ b/src/HelloWorlds/HelloWorldStaticText/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(HelloWorldStaticText)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES HelloWorldStaticText.cpp)

--- a/src/HelloWorlds/wxWidgetsHelloWorld/CMakeLists.txt
+++ b/src/HelloWorlds/wxWidgetsHelloWorld/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(wxWidgetsHelloWorld)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES wxWidgetsHelloWorld.cpp)

--- a/src/MenusAndToolbars/MainMenu/CMakeLists.txt
+++ b/src/MenusAndToolbars/MainMenu/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(MainMenu)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/MenusAndToolbars/Menu/CMakeLists.txt
+++ b/src/MenusAndToolbars/Menu/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Menu)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/MenusAndToolbars/StatusBar/CMakeLists.txt
+++ b/src/MenusAndToolbars/StatusBar/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StatusBar)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/MenusAndToolbars/ToolBar/CMakeLists.txt
+++ b/src/MenusAndToolbars/ToolBar/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ToolBar)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/MiscellaneousWindows/BannerWindow/CMakeLists.txt
+++ b/src/MiscellaneousWindows/BannerWindow/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(BannerWindow)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/OpenGL/Dice/CMakeLists.txt
+++ b/src/OpenGL/Dice/CMakeLists.txt
@@ -6,7 +6,7 @@ project(Dice)
 set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
-find_package(wxWidgets REQUIRED COMPONENTS base core gl)
+find_package(wxWidgets 3.1.4 REQUIRED COMPONENTS base core gl)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Dice.cpp)

--- a/src/Others/AutoScroll/CMakeLists.txt
+++ b/src/Others/AutoScroll/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(AutoScroll)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/BitmapButtonWithLabel/CMakeLists.txt
+++ b/src/Others/BitmapButtonWithLabel/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(BitmapButtonWithLabel)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/BoxedPanel/CMakeLists.txt
+++ b/src/Others/BoxedPanel/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(BoxedPanel)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/ColoredFrames/CMakeLists.txt
+++ b/src/Others/ColoredFrames/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ColoredFrames)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/Colors/CMakeLists.txt
+++ b/src/Others/Colors/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(Colors)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Colors.cpp)

--- a/src/Others/CursorFromFile/CMakeLists.txt
+++ b/src/Others/CursorFromFile/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(CursorFromFile)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/DirDialogShowWindowModal/CMakeLists.txt
+++ b/src/Others/DirDialogShowWindowModal/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(DirDialogShowWindowModal)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/DisplayInformations/CMakeLists.txt
+++ b/src/Others/DisplayInformations/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(DisplayInformations)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/FrameAndThread/CMakeLists.txt
+++ b/src/Others/FrameAndThread/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FrameAndThread)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/FrameAndThreadWithCallAfter/CMakeLists.txt
+++ b/src/Others/FrameAndThreadWithCallAfter/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FrameAndThreadWithCallAfter)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/FrameIcon/CMakeLists.txt
+++ b/src/Others/FrameIcon/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FrameIcon)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/FrameShow/CMakeLists.txt
+++ b/src/Others/FrameShow/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FrameShow)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/MessageDialogShowWindowModal/CMakeLists.txt
+++ b/src/Others/MessageDialogShowWindowModal/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(MessageDialogShowWindowModal)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/OpenFileDialogShowWindowModal/CMakeLists.txt
+++ b/src/Others/OpenFileDialogShowWindowModal/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(OpenFileDialogShowWindowModal)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/SaveFileDialogShowWindowModal/CMakeLists.txt
+++ b/src/Others/SaveFileDialogShowWindowModal/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SaveFileDialogShowWindowModal)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/ShellExecute/CMakeLists.txt
+++ b/src/Others/ShellExecute/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ShellExecute)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/StaticBoxAndCheckBox/CMakeLists.txt
+++ b/src/Others/StaticBoxAndCheckBox/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticBoxAndCheckBox)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/StaticBoxAndRadioButton/CMakeLists.txt
+++ b/src/Others/StaticBoxAndRadioButton/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticBoxAndRadioButton)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/StaticTextAndUnicode/CMakeLists.txt
+++ b/src/Others/StaticTextAndUnicode/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(StaticTextAndUnicode)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/TextCtrlMultiline/CMakeLists.txt
+++ b/src/Others/TextCtrlMultiline/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TextCtrlMultiline)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/TextEntryDialogAsPassword/CMakeLists.txt
+++ b/src/Others/TextEntryDialogAsPassword/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TextEntryDialogAsPassword)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/TextEntryDialogMultiline/CMakeLists.txt
+++ b/src/Others/TextEntryDialogMultiline/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TextEntryDialogMulttiline)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Others/UserDialogShowWindowModal/CMakeLists.txt
+++ b/src/Others/UserDialogShowWindowModal/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(UserDialogShowWindowModal)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Painting/DeviceContext/CMakeLists.txt
+++ b/src/Painting/DeviceContext/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(DeviceContext)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Painting/GraphicsContext/CMakeLists.txt
+++ b/src/Painting/GraphicsContext/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(GraphicsContext)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/PickerControls/ColourPickerCtrl/CMakeLists.txt
+++ b/src/PickerControls/ColourPickerCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(ColourPickerCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/PickerControls/DatePickerCtrl/CMakeLists.txt
+++ b/src/PickerControls/DatePickerCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(DatePickerCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/PickerControls/DirPickerCtrl/CMakeLists.txt
+++ b/src/PickerControls/DirPickerCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(DirPickerCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/PickerControls/FilePickerCtrl/CMakeLists.txt
+++ b/src/PickerControls/FilePickerCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FilePickerCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/PickerControls/FontPickerCtrl/CMakeLists.txt
+++ b/src/PickerControls/FontPickerCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(FontPickerCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/PickerControls/TimePickerCtrl/CMakeLists.txt
+++ b/src/PickerControls/TimePickerCtrl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TimePickerCtrl)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/Tests/TestConsole/CMakeLists.txt
+++ b/src/Tests/TestConsole/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 # Project
 project(TestConsole)
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 set(SOURCES Console.h TestConsole.cpp)

--- a/src/Tests/TestConsole/Console.h
+++ b/src/Tests/TestConsole/Console.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <wx/app.h>
+#include <wx/image.h>
 
 class wxConsole : protected wxApp {
 public:

--- a/src/Tests/TestGui/CMakeLists.txt
+++ b/src/Tests/TestGui/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(TestGui)
 
 
-find_package(wxWidgets REQUIRED)
+find_package(wxWidgets 3.1.4 REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/WindowDocking/AuiManager/CMakeLists.txt
+++ b/src/WindowDocking/AuiManager/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(AuiManager)
 
 
-find_package(wxWidgets REQUIRED COMPONENTS base core aui)
+find_package(wxWidgets 3.1.4 REQUIRED COMPONENTS base core aui)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/WindowDocking/AuiNotebook/CMakeLists.txt
+++ b/src/WindowDocking/AuiNotebook/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(AuiNotebook)
 
 
-find_package(wxWidgets REQUIRED COMPONENTS base core aui)
+find_package(wxWidgets 3.1.4 REQUIRED COMPONENTS base core aui)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})

--- a/src/WindowDocking/AuiToolbar/CMakeLists.txt
+++ b/src/WindowDocking/AuiToolbar/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(AuiToolbar)
 
 
-find_package(wxWidgets REQUIRED COMPONENTS base core aui)
+find_package(wxWidgets 3.1.4 REQUIRED COMPONENTS base core aui)
 include(${wxWidgets_USE_FILE})
 
 link_libraries(${wxWidgets_LIBRARIES})


### PR DESCRIPTION
Since "This project run with wxWidgets 3.1.4 or above" (as your readme states and I discovered in #6), I suggest this requirement be specified in all the `CMakeLists.txt` files by replacing `find_package(wxWidgets REQUIRED)` with `find_package(wxWidgets 3.1.4 REQUIRED)`.  This will result in `cmake ..` presenting a clear error message when an earlier version is used. I've fixed this in the first commit.

I also found `TestConsole` wouldn't build cause it was missing `#include <wx/image.h>`, which I've fixed in the second commit.