### PR TITLE
store unicode string with 16-bit wchar_t

### DIFF
--- a/src/HelloWorlds/HelloWorldEmoticons/HelloWorldEmoticons.cpp
+++ b/src/HelloWorlds/HelloWorldEmoticons/HelloWorldEmoticons.cpp
@@ -15,7 +15,7 @@ namespace Examples {
     
   private:
     wxPanel* panel = new wxPanel(this);
-    wxStaticText* staticText1 = new wxStaticText(panel, wxID_ANY, "\U0001F44B, \U0001F30E\U00002757");
+    wxStaticText* staticText1 = new wxStaticText(panel, wxID_ANY, L"\U0001F44B, \U0001F30E\U00002757");
   };
 
   class Application : public wxApp {


### PR DESCRIPTION
ensures that string is stored correctly even on UTF-8 systems (which is common for Linuxs)

see https://docs.wxwidgets.org/3.0/overview_unicode.html#overview_unicode_support_default for background.

The original code would result in the HelloWorldEmoticons example window appearing as a thin 1-pixel wide sliver:

![2021-09-15_17-09](https://user-images.githubusercontent.com/6502474/133512661-c0916ff1-98cb-4ce5-a96b-89f50e0daf10.png)

I could only get this unicode to display by prepending an L so that it was stored as a wide UTF16-encoded wchar_t, or if I did an explicit conversion from UTF8 like:

`wxString::FromUTF8("\U0001F44B, \U0001F30E\U00002757")`

I actually don't know the best cross-platform way to handle this, but I think using 'L'  might be.

Now at least I can see it:

![2021-09-15_17-17](https://user-images.githubusercontent.com/6502474/133512839-749d776a-4eb6-4bf4-942d-db7d93a3ed93.png)

Though there is still anoter issue with the wxFrame not updating its size according to the newly set font size, but I have a suspicion that issue is due to https://trac.wxwidgets.org/ticket/16088