### PR TITLE
apply Treebook workaround for UNIX and Mac

### DIFF
--- a/src/BookControls/Treebook/Treebook.cpp
+++ b/src/BookControls/Treebook/Treebook.cpp
@@ -1,8 +1,8 @@
 #include <wx/wx.h>
 #include <wx/treebook.h>
 
-// Workaround : with wxWidgets version <= 3.1.4 Tree position ans size are failed on macOS
-#if __APPLE__
+// Workaround : with wxWidgets version <= 3.1.4 Tree position and size are failed on macOS (and Linux)
+#if (__APPLE__ || __UNIX__)
 #include <wx/treectrl.h>
 class TreeBook : public wxTreebook {
 public:


### PR DESCRIPTION
My Debian 11 KDE desktop apparently experiences the same issue that your workaround for macOS fixes, so I'm applying that to `(__APPLE__ || __UNIX__)` (though I'm not sure that is the best way to do logical operations with #if preprocessor).

This is what it looks like originally:

![2021-09-15_20-40_1](https://user-images.githubusercontent.com/6502474/133531615-2d3f9b35-bff5-4f58-92ad-c2266e3075a3.png)

This is what it looks like with the workaround:

![2021-09-15_20-40](https://user-images.githubusercontent.com/6502474/133531632-cfd50104-dc7d-4701-a82a-1a825d9cdf01.png)
