### PR TITLE
Fixed some typos

### DIFF
--- a/src/Applications/ApplicationAndAssert/ApplicationAndAssert.cpp
+++ b/src/Applications/ApplicationAndAssert/ApplicationAndAssert.cpp
@@ -15,7 +15,7 @@ namespace Examples {
   private:
     void GenerateAssert(wxCommandEvent& event) {
       auto index = 0;
-      wxASSERT_MSG(index > 0, "Index must be greather than 0.");
+      wxASSERT_MSG(index > 0, "Index must be greater than 0.");
     }
     
     void GenerateFail(wxCommandEvent& event) {

--- a/src/Applications/ApplicationAndException/ApplicationAndException.cpp
+++ b/src/Applications/ApplicationAndException/ApplicationAndException.cpp
@@ -60,11 +60,11 @@ namespace Examples {
     }
 
     static int ShowExceptiionError(const std::exception& e) {
-      return wxMessageBox(wxString::Format("Unhandled exception occured in your application. If you click\nOK, the application will ignore this error and attempt to continue.\nIf you click Cancel, the application will close immediately.\n\n%s", e.what()), "Exception occured", wxOK|wxCANCEL|wxICON_ERROR);
+      return wxMessageBox(wxString::Format("Unhandled exception occurred in your application. If you click\nOK, the application will ignore this error and attempt to continue.\nIf you click Cancel, the application will close immediately.\n\n%s", e.what()), "Exception occurred", wxOK|wxCANCEL|wxICON_ERROR);
     }
     
     static int ShowExceptiionError() {
-      return wxMessageBox("Unhandled exception occured in your application. If you click\nOK, the application will ignore this error and attempt to continue.\nIf you click Cancel, the application will close immediately.\n\n(Unknown exception)", "Unknown exception occured", wxOK|wxCANCEL|wxICON_ERROR);
+      return wxMessageBox("Unhandled exception occurred in your application. If you click\nOK, the application will ignore this error and attempt to continue.\nIf you click Cancel, the application will close immediately.\n\n(Unknown exception)", "Unknown exception occurred", wxOK|wxCANCEL|wxICON_ERROR);
     }
 
   private:

--- a/src/CommonControls/FileCtrl/FileCtrl.cpp
+++ b/src/CommonControls/FileCtrl/FileCtrl.cpp
@@ -22,7 +22,7 @@ public:
 class FileCtrl : public wxFileCtrl {
 public:
   FileCtrl(wxWindow*parent, wxWindowID id, const wxString& defaultDirectory = wxEmptyString, const wxString& defaultFilename = wxEmptyString, const wxString& wildCard = wxFileSelectorDefaultWildcardStr, long style = wxFC_DEFAULT_STYLE, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, const wxString& name = wxFileCtrlNameStr) : wxFileCtrl(parent, id, defaultDirectory, defaultFilename, wildCard, style, pos, size, name) {
-    // Workaround : with wxWidgets version <= 3.1.4 folder, exacutable and link are set with specific color (respectively Blue, red and middle gray) on macOS (not standard)
+    // Workaround : with wxWidgets version <= 3.1.4 folder, executable and link are set with specific color (respectively Blue, red and middle gray) on macOS (not standard)
 #if __APPLE__
     for (int i = 0; i < GetFileList()->GetItemCount(); i++)
       GetFileList()->SetItemTextColour(i, GetForegroundColour());

--- a/src/Dialogs/Wizard/Wizard.cpp
+++ b/src/Dialogs/Wizard/Wizard.cpp
@@ -11,7 +11,7 @@ namespace Examples {
       
     private:
       wxWizardPage* previousPage = nullptr;
-      wxStaticText* label = new wxStaticText(this, wxID_ANY, "Wizard pagee 2...", {10, 10});
+      wxStaticText* label = new wxStaticText(this, wxID_ANY, "Wizard page 2...", {10, 10});
     };
     
     class WizardPage1 : public wxWizardPage {
@@ -22,7 +22,7 @@ namespace Examples {
       
     private:
       wxWizard* parent = nullptr;
-      wxStaticText* label = new wxStaticText(this, wxID_ANY, "Wizard pagee 1...", {10, 10});
+      wxStaticText* label = new wxStaticText(this, wxID_ANY, "Wizard page 1...", {10, 10});
     };
     
   public:

--- a/src/Others/DisplayInformations/DisplayInformations.cpp
+++ b/src/Others/DisplayInformations/DisplayInformations.cpp
@@ -4,7 +4,7 @@
 namespace Examples {
   class Frame : public wxFrame {
   public:
-    Frame() : wxFrame(nullptr, wxID_ANY, "Display informations example") {
+    Frame() : wxFrame(nullptr, wxID_ANY, "Display information example") {
       SetClientSize(450, 300);
       
       screenInformationsTextCtrl->SetBackgroundColour({wxTheColourDatabase->Find("Navy")});


### PR DESCRIPTION
Fixed following typos, found by running codespell:

./src/Applications/ApplicationAndAssert/ApplicationAndAssert.cpp:18: greather ==> greater
./src/Applications/ApplicationAndException/ApplicationAndException.cpp:63: occured ==> occurred
./src/Applications/ApplicationAndException/ApplicationAndException.cpp:63: occured ==> occurred
./src/Applications/ApplicationAndException/ApplicationAndException.cpp:67: occured ==> occurred
./src/Applications/ApplicationAndException/ApplicationAndException.cpp:67: occured ==> occurred
./src/Others/DisplayInformations/DisplayInformations.cpp:7: informations ==> information
./src/Dialogs/Wizard/Wizard.cpp:14: pagee ==> page
./src/Dialogs/Wizard/Wizard.cpp:25: pagee ==> page
